### PR TITLE
Add MCP server integration for Claude Desktop/Code/Cursor

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,63 @@
+# SCAIPOT Development Rules for Cursor AI
+
+## Project Overview
+SCAIPOT is an AI-powered cryptocurrency scammer honeypot system. It uses Claude API for
+conversational AI, Redis for session caching, PostgreSQL for persistence, and MCP-Prompts
+for dynamic persona management across Telegram, Signal, and WhatsApp platforms.
+
+## Code Style
+- Black formatting: 100 character line length (enforce strictly)
+- Type hints required on ALL function signatures (parameters + return types)
+- Async/await required for ALL I/O operations (network, database, Redis, file)
+- Structured logging via `structlog` or stdlib `logging`, never bare `print()`
+- Import order: stdlib → third-party → local (isort enforced)
+
+## Architecture Patterns
+- All bot adapters must inherit from `src/scaipot/bots/base_adapter.py:BaseBotAdapter`
+- New behaviors go in `src/scaipot/behaviors/` with async methods
+- External API calls → use `httpx.AsyncClient` with timeout and retry
+- Redis keys format: `scaipot:{platform}:{user_id}` for sessions
+- Cache keys format: `scaipot:prompt:category:{name}:v{version}` for prompts
+- PostgreSQL access via SQLAlchemy 2.0 async engine only
+
+## Claude API / LLM Rules
+- ALWAYS include `cache_control: {"type": "ephemeral"}` on system prompt blocks
+- Use `AsyncAnthropic` client (never sync `Anthropic` in async contexts)
+- Default model: `claude-3-5-sonnet-20241022`, max_tokens: 2048, temperature: 1.0
+- Log cache hit/miss stats via `_log_cache_usage()` in every response
+- Never hardcode system prompts — always fetch from MCP-Prompts server
+
+## Security Rules
+- NEVER commit `.env` files or API keys to Git
+- NEVER log raw API keys, tokens, or passwords (mask with `***`)
+- Use `yaml.safe_load()` — never `yaml.load()`
+- Validate all user input at platform adapter boundary before passing to orchestrator
+- Production: enforce `ENV=production` → validates JWT_SECRET and DB password strength
+
+## Testing Rules
+- Unit tests: use `pytest-asyncio` with `asyncio_mode = "auto"`
+- Mock external services: `AsyncMock` for Claude API, `fakeredis` for Redis
+- Every new module must have a corresponding `tests/unit/test_{module}.py`
+- Aim for 75%+ coverage; run: `pytest tests/ --cov=src/scaipot --cov-report=html`
+- Integration tests require Docker: `docker-compose up -d postgres redis`
+
+## MCP Integration
+- Fetch category prompts via `src/scaipot/mcp_integration/mcp_client.py:MCPPromptsClient`
+- MCP-Prompts server runs at `MCP_PROMPTS_URL` (default: `http://mcp-prompts:3003`)
+- Category endpoint: `GET /v1/prompts/honeypot/category/{name}?platform={platform}`
+- Cache category configs in `ResponseGenerator._category_cache` (in-memory, 24h TTL)
+- SCAIPOT MCP server endpoint: `http://localhost:8001` (for Claude Desktop integration)
+
+## Docker
+- Full stack: `docker-compose up -d`
+- Dev stack (no behaviors): `docker-compose up -d postgres redis mcp-prompts`
+- Signal support: `docker-compose --profile signal up -d`
+- VM spawning: `docker-compose --profile vm-spawning up -d`
+- Monitoring: `docker-compose --profile monitoring up -d`
+
+## Common Pitfalls to Avoid
+- Don't use `asyncio.run()` inside async functions — use `await` directly
+- Don't bypass prompt caching by building system prompts inline — use ResponseGenerator
+- Don't hardcode platform names — use `IncomingMessage.platform` from base adapter
+- Don't store sensitive data in Redis without TTL — always set expiration
+- Don't use `docker.from_env()` directly — route through docker-socket-proxy service

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,57 @@
+{
+  "name": "SCAIPOT Dev Environment",
+  "image": "mcr.microsoft.com/devcontainers/python:3.11-bullseye",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "version": "latest",
+      "enableNonRootDocker": "true",
+      "moby": "true"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "20"
+    },
+    "ghcr.io/devcontainers/features/git:1": {}
+  },
+  "postCreateCommand": "pip install -e '.[dev]' && cp .env.example .env && echo 'Dev environment ready! Edit .env with your API keys.'",
+  "postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}",
+  "forwardPorts": [8000, 8001, 3003, 5432, 6379, 3000],
+  "portsAttributes": {
+    "8000": {"label": "SCAIPOT FastAPI", "onAutoForward": "notify"},
+    "8001": {"label": "SCAIPOT MCP Server", "onAutoForward": "notify"},
+    "3003": {"label": "MCP-Prompts Server", "onAutoForward": "silent"},
+    "5432": {"label": "PostgreSQL", "onAutoForward": "silent"},
+    "6379": {"label": "Redis", "onAutoForward": "silent"},
+    "3000": {"label": "Grafana", "onAutoForward": "silent"}
+  },
+  "mounts": [
+    "source=${localWorkspaceFolder}/.env,target=/workspaces/honeybot/.env,type=bind,consistency=cached"
+  ],
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "python.defaultInterpreterPath": "/usr/local/bin/python",
+        "python.testing.pytestEnabled": true,
+        "python.testing.pytestArgs": ["tests/", "-v"],
+        "editor.formatOnSave": true,
+        "editor.rulers": [100]
+      },
+      "extensions": [
+        "ms-python.python",
+        "ms-python.black-formatter",
+        "ms-python.isort",
+        "ms-python.flake8",
+        "ms-python.mypy-type-checker",
+        "GitHub.copilot",
+        "GitHub.copilot-chat",
+        "ms-azuretools.vscode-docker",
+        "redhat.vscode-yaml",
+        "humao.rest-client",
+        "eamodio.gitlens"
+      ]
+    }
+  },
+  "remoteUser": "vscode",
+  "containerEnv": {
+    "PYTHONPATH": "/workspaces/honeybot/src"
+  }
+}

--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,23 @@ DOCKER_HOST=tcp://docker-proxy:2375
 JWT_SECRET=change-this-in-production
 ALLOWED_ORIGINS=http://localhost:3001,https://admin.sparesparrow.dev
 
+# MCP Server (SCAIPOT as MCP tool provider for Claude Desktop / Claude Code / Cursor)
+# Token used to authenticate MCP server → SCAIPOT FastAPI calls
+# Generate: python -c "import secrets; print(secrets.token_urlsafe(32))"
+MCP_SERVER_TOKEN=change-this-mcp-token
+# URL Claude Code/Desktop uses to reach SCAIPOT API (change for remote deployments)
+SCAIPOT_API_URL=http://localhost:8000
+
+# External Intelligence APIs
+# Etherscan: blockchain transaction lookup for extracted BTC/ETH addresses
+ETHERSCAN_API_KEY=your_etherscan_key_here
+# VirusTotal: URL reputation check before URL clicker visits links
+VIRUSTOTAL_API_KEY=your_virustotal_key_here
+# AbuseIPDB: report/query scammer IP addresses
+ABUSEIPDB_API_KEY=your_abuseipdb_key_here
+# Shodan: infrastructure intelligence on scammer IPs
+SHODAN_API_KEY=your_shodan_key_here
+
 # Logging
 LOG_LEVEL=INFO
 LOG_FORMAT=json  # or text

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,22 @@
+{
+  "recommendations": [
+    "ms-python.python",
+    "ms-python.black-formatter",
+    "ms-python.isort",
+    "ms-python.flake8",
+    "ms-python.mypy-type-checker",
+    "GitHub.copilot",
+    "GitHub.copilot-chat",
+    "ms-azuretools.vscode-docker",
+    "redhat.vscode-yaml",
+    "mtxr.sqltools",
+    "mtxr.sqltools-driver-pg",
+    "cweijan.vscode-redis-client",
+    "humao.rest-client",
+    "eamodio.gitlens",
+    "streetsidesoftware.code-spell-checker"
+  ],
+  "unwantedRecommendations": [
+    "ms-python.pylint"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,110 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "SCAIPOT: Main Application",
+      "type": "python",
+      "request": "launch",
+      "module": "scaipot.main",
+      "cwd": "${workspaceFolder}",
+      "envFile": "${workspaceFolder}/.env",
+      "env": {
+        "PYTHONPATH": "${workspaceFolder}/src"
+      },
+      "justMyCode": false,
+      "console": "integratedTerminal"
+    },
+    {
+      "name": "SCAIPOT: MCP Server",
+      "type": "python",
+      "request": "launch",
+      "module": "scaipot.mcp_server",
+      "cwd": "${workspaceFolder}",
+      "envFile": "${workspaceFolder}/.env",
+      "env": {
+        "PYTHONPATH": "${workspaceFolder}/src",
+        "MCP_SERVER_PORT": "8001"
+      },
+      "justMyCode": false,
+      "console": "integratedTerminal"
+    },
+    {
+      "name": "SCAIPOT: CLI",
+      "type": "python",
+      "request": "launch",
+      "module": "scaipot.cli",
+      "args": ["status"],
+      "cwd": "${workspaceFolder}",
+      "envFile": "${workspaceFolder}/.env",
+      "env": {
+        "PYTHONPATH": "${workspaceFolder}/src"
+      },
+      "console": "integratedTerminal"
+    },
+    {
+      "name": "Pytest: All Tests",
+      "type": "python",
+      "request": "launch",
+      "module": "pytest",
+      "args": ["tests/", "-v", "--tb=short"],
+      "cwd": "${workspaceFolder}",
+      "envFile": "${workspaceFolder}/.env",
+      "env": {
+        "PYTHONPATH": "${workspaceFolder}/src"
+      },
+      "console": "integratedTerminal",
+      "justMyCode": false
+    },
+    {
+      "name": "Pytest: Unit Tests Only",
+      "type": "python",
+      "request": "launch",
+      "module": "pytest",
+      "args": ["tests/unit/", "-v", "--tb=short"],
+      "cwd": "${workspaceFolder}",
+      "envFile": "${workspaceFolder}/.env",
+      "env": {
+        "PYTHONPATH": "${workspaceFolder}/src"
+      },
+      "console": "integratedTerminal"
+    },
+    {
+      "name": "Pytest: With Coverage",
+      "type": "python",
+      "request": "launch",
+      "module": "pytest",
+      "args": [
+        "tests/",
+        "-v",
+        "--cov=src/scaipot",
+        "--cov-report=html",
+        "--cov-report=term-missing"
+      ],
+      "cwd": "${workspaceFolder}",
+      "envFile": "${workspaceFolder}/.env",
+      "env": {
+        "PYTHONPATH": "${workspaceFolder}/src"
+      },
+      "console": "integratedTerminal"
+    },
+    {
+      "name": "Pytest: Current File",
+      "type": "python",
+      "request": "launch",
+      "module": "pytest",
+      "args": ["${file}", "-v", "--tb=long", "-s"],
+      "cwd": "${workspaceFolder}",
+      "envFile": "${workspaceFolder}/.env",
+      "env": {
+        "PYTHONPATH": "${workspaceFolder}/src"
+      },
+      "console": "integratedTerminal"
+    }
+  ],
+  "compounds": [
+    {
+      "name": "SCAIPOT: Full Stack (App + MCP)",
+      "configurations": ["SCAIPOT: Main Application", "SCAIPOT: MCP Server"]
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,51 @@
+{
+  "python.defaultInterpreterPath": "${workspaceFolder}/venv/bin/python",
+  "python.formatting.provider": "none",
+  "[python]": {
+    "editor.defaultFormatter": "ms-python.black-formatter",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": "explicit"
+    }
+  },
+  "black-formatter.args": ["--line-length", "100"],
+  "isort.args": ["--profile", "black", "--line-length", "100"],
+  "python.linting.enabled": true,
+  "python.linting.flake8Enabled": true,
+  "python.linting.flake8Args": ["--max-line-length=100", "--extend-ignore=E203,W503"],
+  "python.linting.mypyEnabled": true,
+  "python.linting.mypyArgs": ["--python-version=3.10", "--ignore-missing-imports"],
+  "python.testing.pytestEnabled": true,
+  "python.testing.pytestArgs": ["tests/", "-v"],
+  "python.testing.unittestEnabled": false,
+  "python.analysis.typeCheckingMode": "basic",
+  "editor.rulers": [100],
+  "editor.tabSize": 4,
+  "editor.insertSpaces": true,
+  "files.trimTrailingWhitespace": true,
+  "files.insertFinalNewline": true,
+  "files.exclude": {
+    "**/__pycache__": true,
+    "**/*.pyc": true,
+    "**/.pytest_cache": true,
+    "**/.mypy_cache": true,
+    "**/htmlcov": true,
+    "**/.coverage": true
+  },
+  "github.copilot.enable": {
+    "*": true,
+    "plaintext": false,
+    "markdown": true,
+    "yaml": true
+  },
+  "github.copilot.advanced": {
+    "temperature": 0.1
+  },
+  "yaml.schemas": {
+    "https://json.schemastore.org/github-workflow.json": ".github/workflows/*.yml",
+    "https://json.schemastore.org/docker-compose.json": "docker-compose*.yml"
+  },
+  "docker.dockerComposeBuild": false,
+  "docker.dockerComposeDetached": true,
+  "redhat.telemetry.enabled": false
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -149,6 +149,27 @@ services:
     networks:
       - scaipot_network
 
+  # SCAIPOT MCP Server — exposes honeypot tools to Claude Desktop / Claude Code / Cursor
+  # Register in Claude Desktop: ~/Library/Application Support/Claude/claude_desktop_config.json
+  # Or via Claude Code: claude mcp add scaipot -- python -m scaipot.mcp_server
+  scaipot-mcp:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+    environment:
+      SCAIPOT_API_URL: http://scaipot:8000
+      SCAIPOT_API_TOKEN: ${MCP_SERVER_TOKEN:-}
+      LOG_LEVEL: ${LOG_LEVEL:-WARNING}
+    ports:
+      - "8001:8001"  # Expose for local Claude Desktop registration
+    depends_on:
+      - scaipot
+    command: python -m scaipot.mcp_server
+    networks:
+      - scaipot_network
+    profiles:
+      - mcp  # Enable with: docker-compose --profile mcp up
+
   # Grafana Monitoring (Optional)
   grafana:
     image: grafana/grafana:latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ dev = [
     "pytest-cov>=4.1.0",
     "pytest-mock>=3.11.0",
     "pytest-timeout>=2.2.0",
+    "fakeredis>=2.20.0",  # In-memory Redis mock for unit tests
     "black>=23.0.0",
     "flake8>=6.0.0",
     "isort>=5.12.0",
@@ -84,6 +85,16 @@ dev = [
     "types-requests>=2.31.0",
     "types-pyyaml>=6.0.0",
     "pre-commit>=3.3.0",
+]
+
+intelligence = [
+    # Blockchain / crypto address lookups
+    "web3>=6.0.0",              # Etherscan-compatible RPC calls
+    # URL reputation checking
+    "vt-py>=0.18.0",            # VirusTotal Python SDK
+    # IP reputation / OSINT
+    "shodan>=1.31.0",           # Shodan infrastructure intelligence
+    "aiohttp>=3.9.0",           # AbuseIPDB async HTTP calls (already in core)
 ]
 
 docs = [
@@ -100,6 +111,7 @@ Repository = "https://github.com/sparesparrow/scaipot.git"
 
 [project.scripts]
 scaipot = "scaipot.cli:main"
+scaipot-mcp = "scaipot.mcp_server:main"
 
 [tool.setuptools]
 packages = ["scaipot"]

--- a/src/scaipot/mcp_server.py
+++ b/src/scaipot/mcp_server.py
@@ -1,0 +1,477 @@
+"""
+SCAIPOT MCP Server — exposes honeypot intelligence tools to Claude Desktop,
+Claude Code, and Cursor via the Model Context Protocol.
+
+Run standalone:
+    python -m scaipot.mcp_server
+
+Or via Docker (see docker-compose.yml service: scaipot-mcp).
+
+Register in Claude Desktop (~/Library/Application Support/Claude/claude_desktop_config.json):
+    {
+      "mcpServers": {
+        "scaipot": {
+          "command": "python",
+          "args": ["-m", "scaipot.mcp_server"],
+          "env": {
+            "SCAIPOT_API_URL": "http://localhost:8000",
+            "SCAIPOT_API_TOKEN": "<your-jwt-token>"
+          }
+        }
+      }
+    }
+
+Register in Claude Code (settings.json → mcpServers):
+    Same config as above but set via `claude mcp add` or settings UI.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import sys
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# MCP Protocol helpers — minimal implementation of stdio-based MCP transport
+# ---------------------------------------------------------------------------
+
+PROTOCOL_VERSION = "2024-11-05"
+SERVER_NAME = "scaipot"
+SERVER_VERSION = "0.1.0"
+
+TOOLS: List[Dict[str, Any]] = [
+    {
+        "name": "get_active_sessions",
+        "description": (
+            "List all currently active honeypot sessions (ongoing scammer conversations). "
+            "Returns session IDs, platforms, honeypot categories, message counts, and "
+            "last activity timestamps."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "platform": {
+                    "type": "string",
+                    "description": "Filter by platform: telegram, signal, or whatsapp",
+                    "enum": ["telegram", "signal", "whatsapp"],
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum number of sessions to return (default 50)",
+                    "default": 50,
+                    "minimum": 1,
+                    "maximum": 200,
+                },
+            },
+            "required": [],
+        },
+    },
+    {
+        "name": "get_conversation",
+        "description": (
+            "Retrieve the full conversation history and metadata for a specific honeypot "
+            "session. Returns all messages exchanged, risk assessments, and extracted "
+            "scam indicators (BTC addresses, URLs, phone numbers, etc.)."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "session_id": {
+                    "type": "string",
+                    "description": "Session ID in format platform:user_id (e.g. telegram:123456)",
+                }
+            },
+            "required": ["session_id"],
+        },
+    },
+    {
+        "name": "analyze_message",
+        "description": (
+            "Run SCAIPOT's fraud detection engine on arbitrary text. Extracts scam indicators "
+            "(BTC/ETH addresses, URLs, IBANs, phone numbers, suspicious keywords) and returns "
+            "a risk score with confidence level and recommended actions."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "text": {
+                    "type": "string",
+                    "description": "Message text to analyze for scam patterns",
+                }
+            },
+            "required": ["text"],
+        },
+    },
+    {
+        "name": "get_statistics",
+        "description": (
+            "Get system-wide SCAIPOT statistics: active sessions count, total messages "
+            "processed, fraud detections, alerts generated, platform breakdown, and "
+            "system uptime."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {},
+            "required": [],
+        },
+    },
+    {
+        "name": "list_categories",
+        "description": (
+            "List all available honeypot persona categories (e.g. bitcoin_investment, "
+            "romance_scam, pig_butchering). Returns category names with descriptions "
+            "of the persona and the scam type they target."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {},
+            "required": [],
+        },
+    },
+    {
+        "name": "get_alerts",
+        "description": (
+            "Retrieve recent high-risk alerts triggered by the fraud detection system. "
+            "Includes session IDs, alert types, severity levels, and whether they've been "
+            "acknowledged by an admin."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum number of alerts to return (default 20)",
+                    "default": 20,
+                    "minimum": 1,
+                    "maximum": 100,
+                },
+                "unacknowledged_only": {
+                    "type": "boolean",
+                    "description": "If true, return only unacknowledged alerts",
+                    "default": False,
+                },
+            },
+            "required": [],
+        },
+    },
+    {
+        "name": "terminate_session",
+        "description": (
+            "Terminate an active honeypot session, ending the conversation with the scammer "
+            "and archiving the session data. Use when a session has been fully analyzed or "
+            "poses an operational risk."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "session_id": {
+                    "type": "string",
+                    "description": "Session ID to terminate",
+                },
+                "reason": {
+                    "type": "string",
+                    "description": "Reason for termination (for audit log)",
+                    "default": "Manual termination via MCP",
+                },
+            },
+            "required": ["session_id"],
+        },
+    },
+    {
+        "name": "health_check",
+        "description": (
+            "Check the health status of all SCAIPOT components: API server, Claude LLM "
+            "connection, Redis session store, PostgreSQL database, and MCP-Prompts server."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {},
+            "required": [],
+        },
+    },
+]
+
+
+class ScaipotAPIClient:
+    """Thin HTTP client wrapping the SCAIPOT FastAPI admin endpoints."""
+
+    def __init__(self, base_url: str, token: Optional[str] = None):
+        self.base_url = base_url.rstrip("/")
+        self.token = token
+        self._client: Optional[httpx.AsyncClient] = None
+
+    async def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None or self._client.is_closed:
+            headers: Dict[str, str] = {"Content-Type": "application/json"}
+            if self.token:
+                headers["Authorization"] = f"Bearer {self.token}"
+            self._client = httpx.AsyncClient(
+                base_url=self.base_url,
+                headers=headers,
+                timeout=30.0,
+            )
+        return self._client
+
+    async def close(self) -> None:
+        if self._client and not self._client.is_closed:
+            await self._client.aclose()
+
+    async def get(self, path: str, params: Optional[Dict] = None) -> Dict[str, Any]:
+        client = await self._get_client()
+        response = await client.get(path, params=params)
+        response.raise_for_status()
+        return response.json()
+
+    async def delete(self, path: str) -> None:
+        client = await self._get_client()
+        response = await client.delete(path)
+        response.raise_for_status()
+
+
+class ScaipotMCPServer:
+    """
+    Stdio-based MCP server that proxies SCAIPOT FastAPI endpoints as MCP tools.
+    Implements the MCP 2024-11-05 protocol over stdin/stdout.
+    """
+
+    def __init__(self, api_url: str, api_token: Optional[str] = None):
+        self.api = ScaipotAPIClient(api_url, api_token)
+        self._initialized = False
+
+    # ------------------------------------------------------------------
+    # Tool dispatch
+    # ------------------------------------------------------------------
+
+    async def call_tool(self, name: str, arguments: Dict[str, Any]) -> str:
+        """Dispatch a tool call and return result as a JSON string."""
+        try:
+            if name == "get_active_sessions":
+                return await self._get_active_sessions(arguments)
+            elif name == "get_conversation":
+                return await self._get_conversation(arguments)
+            elif name == "analyze_message":
+                return await self._analyze_message(arguments)
+            elif name == "get_statistics":
+                return await self._get_statistics()
+            elif name == "list_categories":
+                return await self._list_categories()
+            elif name == "get_alerts":
+                return await self._get_alerts(arguments)
+            elif name == "terminate_session":
+                return await self._terminate_session(arguments)
+            elif name == "health_check":
+                return await self._health_check()
+            else:
+                return json.dumps({"error": f"Unknown tool: {name}"})
+        except httpx.HTTPStatusError as e:
+            return json.dumps(
+                {"error": f"API error {e.response.status_code}: {e.response.text}"}
+            )
+        except httpx.ConnectError:
+            return json.dumps(
+                {
+                    "error": (
+                        f"Cannot connect to SCAIPOT at {self.api.base_url}. "
+                        "Is the server running? Try: docker-compose up -d"
+                    )
+                }
+            )
+        except Exception as e:
+            logger.exception(f"Tool call failed: {name}")
+            return json.dumps({"error": str(e)})
+
+    async def _get_active_sessions(self, args: Dict[str, Any]) -> str:
+        params: Dict[str, Any] = {"page_size": args.get("limit", 50)}
+        if platform := args.get("platform"):
+            params["platform"] = platform
+        data = await self.api.get("/api/sessions", params=params)
+        return json.dumps(data, indent=2)
+
+    async def _get_conversation(self, args: Dict[str, Any]) -> str:
+        session_id = args["session_id"]
+        data = await self.api.get(f"/api/sessions/{session_id}")
+        return json.dumps(data, indent=2)
+
+    async def _analyze_message(self, args: Dict[str, Any]) -> str:
+        # Use the SCAIPOT fraud detection engine via a lightweight inline call
+        # Falls back to a direct import if the API isn't running locally
+        text = args["text"]
+        try:
+            # Try via API first (works when SCAIPOT is running in Docker)
+            data = await self.api.get(
+                "/api/analyze", params={"text": text}
+            )
+            return json.dumps(data, indent=2)
+        except httpx.HTTPStatusError:
+            # Endpoint not yet implemented — use local import fallback
+            try:
+                from scaipot.fraud_detection.pattern_detector import PatternDetector
+
+                detector = PatternDetector()
+                result = await detector.analyze_message(text)
+                return json.dumps(result, indent=2)
+            except ImportError:
+                return json.dumps(
+                    {"error": "analyze endpoint not available and local import failed"}
+                )
+
+    async def _get_statistics(self) -> str:
+        data = await self.api.get("/api/statistics")
+        return json.dumps(data, indent=2)
+
+    async def _list_categories(self) -> str:
+        data = await self.api.get("/api/categories")
+        return json.dumps(data, indent=2)
+
+    async def _get_alerts(self, args: Dict[str, Any]) -> str:
+        params = {
+            "limit": args.get("limit", 20),
+            "unacknowledged_only": str(args.get("unacknowledged_only", False)).lower(),
+        }
+        data = await self.api.get("/api/alerts", params=params)
+        return json.dumps(data, indent=2)
+
+    async def _terminate_session(self, args: Dict[str, Any]) -> str:
+        session_id = args["session_id"]
+        await self.api.delete(f"/api/sessions/{session_id}")
+        return json.dumps(
+            {"success": True, "session_id": session_id, "status": "terminated"}
+        )
+
+    async def _health_check(self) -> str:
+        data = await self.api.get("/api/health")
+        return json.dumps(data, indent=2)
+
+    # ------------------------------------------------------------------
+    # MCP stdio transport
+    # ------------------------------------------------------------------
+
+    def _send(self, message: Dict[str, Any]) -> None:
+        """Write a JSON-RPC message to stdout."""
+        line = json.dumps(message)
+        sys.stdout.write(line + "\n")
+        sys.stdout.flush()
+
+    def _error_response(self, request_id: Any, code: int, message: str) -> Dict:
+        return {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "error": {"code": code, "message": message},
+        }
+
+    async def _handle_request(self, request: Dict[str, Any]) -> None:
+        method = request.get("method", "")
+        request_id = request.get("id")
+        params = request.get("params", {})
+
+        if method == "initialize":
+            self._initialized = True
+            self._send(
+                {
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "result": {
+                        "protocolVersion": PROTOCOL_VERSION,
+                        "capabilities": {"tools": {}},
+                        "serverInfo": {
+                            "name": SERVER_NAME,
+                            "version": SERVER_VERSION,
+                        },
+                    },
+                }
+            )
+
+        elif method == "initialized":
+            # Notification — no response required
+            pass
+
+        elif method == "tools/list":
+            self._send(
+                {
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "result": {"tools": TOOLS},
+                }
+            )
+
+        elif method == "tools/call":
+            tool_name = params.get("name", "")
+            arguments = params.get("arguments", {})
+            content = await self.call_tool(tool_name, arguments)
+            self._send(
+                {
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "result": {
+                        "content": [{"type": "text", "text": content}],
+                        "isError": content.startswith('{"error"'),
+                    },
+                }
+            )
+
+        elif method == "ping":
+            self._send({"jsonrpc": "2.0", "id": request_id, "result": {}})
+
+        else:
+            if request_id is not None:
+                self._send(
+                    self._error_response(request_id, -32601, f"Method not found: {method}")
+                )
+
+    async def run(self) -> None:
+        """Run the MCP server, reading JSON-RPC messages from stdin."""
+        logger.info(
+            f"SCAIPOT MCP server starting — API: {self.api.base_url}"
+        )
+
+        loop = asyncio.get_event_loop()
+        reader = asyncio.StreamReader()
+        protocol = asyncio.StreamReaderProtocol(reader)
+        await loop.connect_read_pipe(lambda: protocol, sys.stdin)
+
+        try:
+            while True:
+                try:
+                    line = await reader.readline()
+                    if not line:
+                        break
+                    line_str = line.decode("utf-8").strip()
+                    if not line_str:
+                        continue
+                    request = json.loads(line_str)
+                    await self._handle_request(request)
+                except json.JSONDecodeError as e:
+                    logger.error(f"Invalid JSON: {e}")
+                    self._send(
+                        self._error_response(None, -32700, f"Parse error: {e}")
+                    )
+                except Exception as e:
+                    logger.exception("Unhandled error in request loop")
+                    self._send(self._error_response(None, -32603, str(e)))
+        finally:
+            await self.api.close()
+            logger.info("SCAIPOT MCP server stopped")
+
+
+def main() -> None:
+    """Entry point for the MCP server."""
+    logging.basicConfig(
+        level=logging.WARNING,  # Keep quiet on stderr (MCP uses stdout)
+        stream=sys.stderr,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    api_url = os.environ.get("SCAIPOT_API_URL", "http://localhost:8000")
+    api_token = os.environ.get("SCAIPOT_API_TOKEN")
+
+    server = ScaipotMCPServer(api_url=api_url, api_token=api_token)
+    asyncio.run(server.run())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Adds a Model Context Protocol (MCP) server that exposes SCAIPOT's honeypot intelligence tools to Claude Desktop, Claude Code, and Cursor via stdio-based JSON-RPC transport. This enables AI assistants to query active sessions, analyze messages for fraud patterns, retrieve alerts, and manage honeypot operations directly from their interfaces.

## Key Changes

### Core MCP Server Implementation
- **`src/scaipot/mcp_server.py`** (477 lines): Complete MCP 2024-11-05 protocol implementation
  - `ScaipotAPIClient`: Async HTTP client wrapping SCAIPOT FastAPI admin endpoints with JWT auth
  - `ScaipotMCPServer`: Stdio-based JSON-RPC server handling MCP lifecycle (initialize, tools/list, tools/call)
  - 8 exposed tools: `get_active_sessions`, `get_conversation`, `analyze_message`, `get_statistics`, `list_categories`, `get_alerts`, `terminate_session`, `health_check`
  - Graceful error handling for connection failures with helpful diagnostics
  - Fallback to local `PatternDetector` import when `/api/analyze` endpoint unavailable

### Development Environment
- **`.vscode/launch.json`**: Debug configurations for main app, MCP server, CLI, and pytest (with coverage)
- **`.vscode/settings.json`**: Black (100 char), isort, flake8, mypy, pytest configuration
- **`.vscode/extensions.json`**: Recommended extensions (Python, Docker, REST Client, GitLens, etc.)
- **`.devcontainer/devcontainer.json`**: Full dev container with Docker-in-Docker, Node.js, port forwarding
- **`.cursorrules`**: Comprehensive development guidelines for Cursor AI (async/await, type hints, security, MCP patterns)

### Docker & Configuration
- **`docker-compose.yml`**: New `scaipot-mcp` service running MCP server on port 8001 (optional profile)
- **`.env.example`**: Added MCP configuration variables and external intelligence API keys (Etherscan, VirusTotal, AbuseIPDB, Shodan)

### Dependencies
- **`pyproject.toml`**: Added `fakeredis` for unit test mocking and optional `intelligence` extras group (web3, vt-py, shodan, aiohttp)

## Notable Implementation Details

- **Async-first design**: All I/O operations use `httpx.AsyncClient` with 30s timeout and proper cleanup
- **MCP protocol compliance**: Implements required methods (initialize, tools/list, tools/call, ping) with proper JSON-RPC error codes
- **Resilient error handling**: Distinguishes between API errors, connection failures, and malformed requests; returns actionable error messages
- **Registration instructions**: Comprehensive docstring with setup steps for Claude Desktop, Claude Code, and Cursor
- **Local fallback**: `analyze_message` tool gracefully degrades to local `PatternDetector` if API endpoint unavailable
- **Logging to stderr**: Keeps stdout clean for MCP protocol; logs to stderr with WARNING level by default

## Registration
Users can register the MCP server in Claude Desktop via:
```json
{
  "mcpServers": {
    "scaipot": {
      "command": "python",
      "args": ["-m", "scaipot.mcp_server"],
      "env": {
        "SCAIPOT_API_URL": "http://localhost:8000",
        "SCAIPOT_API_TOKEN": "<jwt-token>"
      }
    }
  }
}
```

Or via Docker: `docker-compose --profile mcp up -d`

https://claude.ai/code/session_01PPqTmXoQ3NNBWS3Q1p71vR